### PR TITLE
Expose Get Executions State and Response

### DIFF
--- a/lib/cloudscrape_client/executions/get.rb
+++ b/lib/cloudscrape_client/executions/get.rb
@@ -1,6 +1,8 @@
 class CloudscrapeClient
   class Executions
     class Get
+      attr_reader :response
+
       def initialize(response:)
         @response = response
       end
@@ -28,10 +30,6 @@ class CloudscrapeClient
       def ok?
         %w(OK).include?(state)
       end
-
-      private
-
-      attr_reader :response
 
       def state
         response.fetch(:state)

--- a/spec/cloudscrape_client/executions/get_spec.rb
+++ b/spec/cloudscrape_client/executions/get_spec.rb
@@ -71,4 +71,12 @@ describe CloudscrapeClient::Executions::Get do
       expect(ok).to eq(true)
     end
   end
+
+  describe "#state" do
+    subject(:state_call) { instance.state }
+
+    it "results state" do
+      expect(state_call).to eq(state)
+    end
+  end
 end


### PR DESCRIPTION
This expands the contract to allow users get the value of state and
response. Useful for saving the state to a DB or dumping the response
for debugging.