### PR TITLE
Handle Result As A Collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+## 0.3.0 (2016-03-23)
+
+Features:
+
+  - wrap executions response in results object to handle collections
+
+Deprecations:
+
+  - deprecate executions `#result` method in favour of `#results`
+
+## Changelog Template
+
+Performance:
+
+  - performance change a
+
+Features:
+
+  - feature a
+
+Bugfixes:
+
+  - bugfix a
+
+Deprecations:
+
+  - deprecation a

--- a/README.md
+++ b/README.md
@@ -105,9 +105,10 @@ client.executions(execution_id).remove
 Methods are dynamically defined based on headers.
 
 ``` ruby
-execution = client.executions(execution_id).result
+execution = client.executions(execution_id).results
 execution.response # => { headers: [...], rows: [...] }
-execution.as_hash # => { ... }
+execution.collection # => [ #<CloudscrapeClient::Executions::Result:0x007ffd7d132950> ]
+execution.as_hash # => [ { ... } ]
 ```
 
 #### Executions (Stop) [Docs](https://app.cloudscrape.com/#/api/sections/executions/stop)

--- a/lib/cloudscrape_client/executions.rb
+++ b/lib/cloudscrape_client/executions.rb
@@ -1,6 +1,7 @@
 require "cloudscrape_client/execution_dto"
 require "cloudscrape_client/executions/get"
 require "cloudscrape_client/executions/result"
+require "cloudscrape_client/executions/results"
 
 class CloudscrapeClient
   class Executions
@@ -13,7 +14,12 @@ class CloudscrapeClient
     end
 
     def result
-      Result.new(response: dto("result", :get))
+      warn "[DEPRECATION] `result` is deprecated. Please use `results` instead."
+      results.collection.first
+    end
+
+    def results
+      @results ||= Results.new(response: dto("result", :get))
     end
 
     def remove

--- a/lib/cloudscrape_client/executions/result.rb
+++ b/lib/cloudscrape_client/executions/result.rb
@@ -1,10 +1,11 @@
 class CloudscrapeClient
   class Executions
     class Result
-      attr_reader :response
+      attr_reader :row
 
-      def initialize(response:)
-        @response = response
+      def initialize(headers:, row:)
+        @headers = headers
+        @row = row
         build
       end
 
@@ -13,18 +14,10 @@ class CloudscrapeClient
       end
 
       def as_hash
-        @as_hash ||= Hash[headers.zip(rows)]
+        @as_hash ||= Hash[@headers.zip(row)]
       end
 
       private
-
-      def headers
-        response.fetch(:headers, [])
-      end
-
-      def rows
-        response.fetch(:rows, [[]]).first
-      end
 
       def define_method_for_header
         ->(key, value) { self.class.send(:define_method, key) { value } }

--- a/lib/cloudscrape_client/executions/results.rb
+++ b/lib/cloudscrape_client/executions/results.rb
@@ -1,0 +1,31 @@
+class CloudscrapeClient
+  class Executions
+    class Results
+      attr_reader :response
+
+      def initialize(response:)
+        @response = response
+      end
+
+      def as_hash
+        collection.map(&:as_hash)
+      end
+
+      def collection
+        response.fetch(:rows, [[]]).map(&result)
+      end
+
+      private
+
+      def headers
+        response.fetch(:headers, [])
+      end
+
+      def result
+        lambda do |row|
+          CloudscrapeClient::Executions::Result.new(headers: headers, row: row)
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudscrape_client/version.rb
+++ b/lib/cloudscrape_client/version.rb
@@ -1,3 +1,3 @@
 class CloudscrapeClient
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/spec/cloudscrape_client/executions/result_spec.rb
+++ b/spec/cloudscrape_client/executions/result_spec.rb
@@ -1,7 +1,9 @@
 require "spec_helper"
 
 describe CloudscrapeClient::Executions::Result do
-  let(:instance) { described_class.new(response: response) }
+  let(:instance) do
+    described_class.new(headers: response[:headers], row: response[:rows].first)
+  end
 
   let(:response) do
     {

--- a/spec/cloudscrape_client/executions/results_spec.rb
+++ b/spec/cloudscrape_client/executions/results_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+describe CloudscrapeClient::Executions::Results do
+  let(:instance) { described_class.new(response: response) }
+
+  let(:response) do
+    {
+      headers: %w(name age location avatars errors),
+      rows: [row1, row2]
+    }
+  end
+
+  let(:row1) { ["Chuck", 31, "Manchester", avatars, nil] }
+  let(:row2) { ["James", 26, "London", avatars, nil] }
+  let(:avatars) { ["https://example.com/avatar1.png"] }
+
+  describe "#as_hash" do
+    subject(:as_hash) { instance.as_hash }
+
+    let(:expected_hash) do
+      [
+        {
+          "name" => "Chuck",
+          "age" => 31,
+          "location" => "Manchester",
+          "avatars" => avatars,
+          "errors" => nil
+        },
+        {
+          "name" => "James",
+          "age" => 26,
+          "location" => "London",
+          "avatars" => avatars,
+          "errors" => nil
+        }
+      ]
+    end
+
+    it "results hash with headers as keys and rows as values" do
+      expect(as_hash).to eq(expected_hash)
+    end
+  end
+
+  describe "#collection" do
+    subject(:collection) { instance.collection }
+
+    it "returns a collection of Result objects" do
+      expect(collection.map(&:class)).to eq([
+        CloudscrapeClient::Executions::Result,
+        CloudscrapeClient::Executions::Result
+      ])
+    end
+  end
+end


### PR DESCRIPTION
- [x] Test in Production
- [x] Bump Version `0.3.0`
- [x] Add Changelog

This change deprecates the `#result` call from an executions in favour of `#results` which allows collections within executions to be handled correctly.