### PR TITLE
Add new feature for ExecuteBulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.2 (2017-09-01)
+
+Features:
+
+  - Added executeBulk endpoint support for runs
+
 ## 0.5.0 (2016-09-16)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ When `connect: true` is passed execution will upload it's result to configured i
 execution_id = client.runs(run_id).execute(input: { url: 'http://google.com' }, connect: true)
 ```
 
+#### Runs (Execute Bulk) [Docs](https://app.dexi.io/#/api/sections/runs/executeBulk)
+
+When `connect: true` is passed execution will upload it's result to configured integrations for this run.
+
+``` ruby
+execution_id = client.runs(run_id).execute(input: [{ url: 'http://google.com' },{ url: 'http://bbc.com' }], connect: true)
+```
+
 #### Executions (Get) [Docs](https://app.dexi.io/#/api/sections/executions/get)
 
 ``` ruby

--- a/lib/cloudscrape_client/dto.rb
+++ b/lib/cloudscrape_client/dto.rb
@@ -35,10 +35,7 @@ class CloudscrapeClient
         domain: domain,
         url: endpoint,
         content_type: content_type,
-        options: {
-          api_key: api_key,
-          format: "json"
-        }.merge(params)
+        options: params
       ).tap(&CloudscrapeClient::Validate).body
     end
 

--- a/lib/cloudscrape_client/runs.rb
+++ b/lib/cloudscrape_client/runs.rb
@@ -20,13 +20,12 @@ class CloudscrapeClient
 
   private
     def url(input)
-      case input
-      when Array
-        "execute/bulk"
-      when Hash
-        "execute/inputs"
-      else
+      if input.empty?
         "execute"
+      elsif input.is_a?(Array)
+        "execute/bulk"
+      else
+        "execute/inputs"
       end
     end
   end

--- a/lib/cloudscrape_client/runs.rb
+++ b/lib/cloudscrape_client/runs.rb
@@ -18,7 +18,8 @@ class CloudscrapeClient
       ).fetch(:_id)
     end
 
-  private
+    private
+
     def url(input)
       if input.empty?
         "execute"

--- a/lib/cloudscrape_client/runs.rb
+++ b/lib/cloudscrape_client/runs.rb
@@ -11,11 +11,23 @@ class CloudscrapeClient
     def execute(input: {}, connect: false)
       RunDTO.for(
         id: @id,
-        url: (input.empty? ? "execute" : "execute/inputs"),
+        url: url(input),
         input: input,
         connect: connect,
         method: :post
       ).fetch(:_id)
+    end
+
+  private
+    def url(input)
+      case input
+      when Array
+        "execute/bulk"
+      when Hash
+        "execute/inputs"
+      else
+        "execute"
+      end
     end
   end
 end

--- a/lib/cloudscrape_client/version.rb
+++ b/lib/cloudscrape_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class CloudscrapeClient
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end

--- a/spec/cloudscrape_client/dto_spec.rb
+++ b/spec/cloudscrape_client/dto_spec.rb
@@ -24,10 +24,7 @@ RSpec.describe CloudscrapeClient::DTO do
         domain: domain,
         url: endpoint,
         content_type: "application/json",
-        options: {
-          api_key: CloudscrapeClient.configuration.api_key,
-          format: "json"
-        }
+        options: {}
       ) { response }
 
       expect(subject).to eq({})
@@ -50,10 +47,7 @@ RSpec.describe CloudscrapeClient::DTO do
         domain: domain,
         url: endpoint,
         content_type: "application/json",
-        options: {
-          api_key: CloudscrapeClient.configuration.api_key,
-          format: "json"
-        }
+        options: {}
       ) { response }
 
       expect(subject).to eq({})
@@ -76,10 +70,7 @@ RSpec.describe CloudscrapeClient::DTO do
         domain: domain,
         url: endpoint,
         content_type: "application/json",
-        options: {
-          api_key: CloudscrapeClient.configuration.api_key,
-          format: "json"
-        }
+        options: {}
       ) { response }
 
       expect(subject).to eq({})

--- a/spec/cloudscrape_client/execution_dto_spec.rb
+++ b/spec/cloudscrape_client/execution_dto_spec.rb
@@ -24,10 +24,7 @@ RSpec.describe CloudscrapeClient::ExecutionDTO do
       domain: "https://api.dexi.io/",
       url: "executions/#{execution_id}/#{url}/#{record_id}",
       content_type: content_type,
-      options: {
-        api_key: CloudscrapeClient.configuration.api_key,
-        format: "json"
-      }
+      options: {}
     ) { response }
 
     expect(run).to eq({})
@@ -47,10 +44,7 @@ RSpec.describe CloudscrapeClient::ExecutionDTO do
         domain: "https://api.dexi.io/",
         url: "executions/#{execution_id}/#{url}",
         content_type: CloudscrapeClient::DTO::DEFAULT_CONTENT_TYPE,
-        options: {
-          api_key: CloudscrapeClient.configuration.api_key,
-          format: "json"
-        }
+        options: {}
       ) { response }
 
       expect(run).to eq({})

--- a/spec/cloudscrape_client/run_dto_spec.rb
+++ b/spec/cloudscrape_client/run_dto_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe CloudscrapeClient::RunDTO do
       url: "runs/#{id}/#{url}?connect=true",
       content_type: CloudscrapeClient::DTO::DEFAULT_CONTENT_TYPE,
       options: {
-        api_key: CloudscrapeClient.configuration.api_key,
-        format: "json",
         url: input[:url]
       }
     ) { response }

--- a/spec/cloudscrape_client/runs_spec.rb
+++ b/spec/cloudscrape_client/runs_spec.rb
@@ -27,5 +27,17 @@ RSpec.describe CloudscrapeClient::Runs do
         end
       end
     end
+
+    context "when bulk" do
+      subject(:execute) { instance.execute(input: input) }
+
+      let(:input) { [{ url: "http://www.google.com" }] }
+
+      it "calls off to RunDTO and returns" do
+        VCR.use_cassette("valid/runs/execute_bulk") do
+          expect(execute).to eq("5226842f-175c-492f-835a-1f822676f10b")
+        end
+      end
+    end
   end
 end

--- a/spec/fixtures/cassettes/valid/executions/file.yml
+++ b/spec/fixtures/cassettes/valid/executions/file.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.dexi.io/executions/ae101b8f-1326-451c-ada7-3eab3c0f8a91/file/11fed7f0-a508-4dc8-956a-481535c6f88a?api_key=<CLOUD_SCRAPE_CLIENT_API_KEY_OVERRIDE>&format=json
+    uri: https://api.dexi.io/executions/ae101b8f-1326-451c-ada7-3eab3c0f8a91/file/11fed7f0-a508-4dc8-956a-481535c6f88a
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/valid/executions/remove.yml
+++ b/spec/fixtures/cassettes/valid/executions/remove.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://api.dexi.io/executions/3a8ea1f2-6781-4371-841f-66f6210a27b9/?api_key=<CLOUD_SCRAPE_CLIENT_API_KEY_OVERRIDE>&format=json
+    uri: https://api.dexi.io/executions/3a8ea1f2-6781-4371-841f-66f6210a27b9/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/valid/executions/result.yml
+++ b/spec/fixtures/cassettes/valid/executions/result.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.dexi.io/executions/3a8ea1f2-6781-4371-841f-66f6210a27b9/result?api_key=<CLOUD_SCRAPE_CLIENT_API_KEY_OVERRIDE>&format=json
+    uri: https://api.dexi.io/executions/3a8ea1f2-6781-4371-841f-66f6210a27b9/result
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/valid/runs/execute_bulk.yml
+++ b/spec/fixtures/cassettes/valid/runs/execute_bulk.yml
@@ -1,22 +1,22 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://api.dexi.io/executions/3a8ea1f2-6781-4371-841f-66f6210a27b9/
+    method: post
+    uri: https://api.dexi.io/runs/27c719bb-f28f-49f5-aedf-dba2f8e60ba3/execute/bulk?connect=false
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"api_key":"<CLOUD_SCRAPE_CLIENT_API_KEY_OVERRIDE>","format":"json","url":"http://www.google.com"}'
     headers:
       User-Agent:
-      - CS-RUBY-CLIENT/1.0 (ChuckJHardy; Chuck; 58234) ruby/2.2.3 (173; x86_64-darwin14)
+      - CS-RUBY-CLIENT/1.0 (Charless-Air; Chuck; 26883) ruby/2.2.1 (85; x86_64-darwin15)
+      Content-Type:
+      - application/json
       Accept:
       - application/json
       X-Cloudscrape-Access:
       - d7818ef991012e3c94e8ea3cda149936
       X-Cloudscrape-Account:
       - "<CLOUD_SCRAPE_CLIENT_ACCOUNT_ID_OVERRIDE>"
-      Content-Type:
-      - application/json
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -27,19 +27,19 @@ http_interactions:
       X-Powered-By:
       - Express
       Date:
-      - Sat, 10 Oct 2015 00:18:59 GMT
+      - Fri, 16 Oct 2015 17:44:10 GMT
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding, User-Agent
       Set-Cookie:
-      - cssesid=s%3AnijJ6ROF2fNWLSSTMQTfIQxVaGvqchBs.hgbKDyRGBaBYzsvf5ZwlC2DP08EhecQwccdxA4dyQsw;
+      - cssesid=s%3A_TX26BJe8-w2w-D8MNWjdoeFG-DXvAZc.9rsbSUY6t3ttAf5NtDBgN7gxi6wzHgdN3Tq80lrhnXw;
         Path=/
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"_id":"3a8ea1f2-6781-4371-841f-66f6210a27b9","state":"OK","starts":1444436313493,"finished":1444436317128}'
+      string: '{"_id":"5226842f-175c-492f-835a-1f822676f10b","state":"PENDING","starts":1445017450586,"finished":null}'
     http_version: 
-  recorded_at: Sat, 10 Oct 2015 00:18:58 GMT
+  recorded_at: Fri, 16 Oct 2015 17:44:11 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Add [executeBulk](https://app.dexi.io/#/api/sections/runs/executeBulk)

One problem I encountered is that `executeBulk` expects a JSON array in the body.  

But the gem forced all things into a `{}` – [dto.rb](https://github.com/cloudscrape/cloudscrape-client-ruby/blob/master/lib/cloudscrape_client/dto.rb#L38-L41) sets a `{}` every time with `api_key` and `format`.  I believe that is unnecessary now since those are passed as headers.  So I removed those from being passed over every time and updated the specs.  LMK if that is a breaking change.



