### PR TITLE
Fix bug in CloudscrapeClient::Executions::Results#collection

### DIFF
--- a/cloudscrape-client-ruby.gemspec
+++ b/cloudscrape-client-ruby.gemspec
@@ -39,5 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"
+  spec.add_development_dependency 'pry-byebug'
 end
 # rubocop:enable Metrics/BlockLength

--- a/lib/cloudscrape_client/executions/result.rb
+++ b/lib/cloudscrape_client/executions/result.rb
@@ -25,7 +25,7 @@ class CloudscrapeClient
 
       def define_method_for_header
         lambda do |key, value|
-          self.class.send(:define_method, key) do
+          define_singleton_method(key) do
             value.to_s.include?(File::FILE_KEYWORD) ? File.new(value) : value
           end
         end

--- a/spec/cloudscrape_client/executions/results_spec.rb
+++ b/spec/cloudscrape_client/executions/results_spec.rb
@@ -54,5 +54,11 @@ RSpec.describe CloudscrapeClient::Executions::Results do
         ]
       )
     end
+
+    it "returns the right values for each Result object" do
+      expect(collection.map(&:name)).to eq ["Chuck", "James"]
+      expect(collection.map(&:age)).to eq [31, 26]
+      expect(collection.map(&:location)).to eq ["Manchester", "London"]
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "simplecov"
+require 'pry'
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "cloudscrape_client"


### PR DESCRIPTION
So the problem was basically this: 

```
If you use define_method on self.class, you'll create the new method as an instance method on the 
whole class so it will be available as a method on all instances of the class.
```

You can read more here: 
https://stackoverflow.com/questions/19368437/how-to-use-define-method-inside-initialize