### PR TITLE
Allow regex to match on / when loading the result file

### DIFF
--- a/lib/cloudscrape_client/executions/result/file.rb
+++ b/lib/cloudscrape_client/executions/result/file.rb
@@ -17,7 +17,7 @@ class CloudscrapeClient
           ;                        # first split
           (?'providerId'\d+)       # Dexi provider id
           ;                        # second split
-          (?'id'[a-z0-9-\/]*)      # file id
+          (?'id'[a-z0-9\-\/]*)     # file id
           \Z                       # end of line
         }x
         EXPECTED_FORMAT = "FILE:<CONTENT_TYPE>;<PROVIDER_ID>;<FILE_ID>"

--- a/lib/cloudscrape_client/executions/result/file.rb
+++ b/lib/cloudscrape_client/executions/result/file.rb
@@ -17,7 +17,7 @@ class CloudscrapeClient
           ;                        # first split
           (?'providerId'\d+)       # Dexi provider id
           ;                        # second split
-          (?'id'[a-z0-9-]*)        # file id
+          (?'id'[a-z0-9-\/]*)      # file id
           \Z                       # end of line
         }x
         EXPECTED_FORMAT = "FILE:<CONTENT_TYPE>;<PROVIDER_ID>;<FILE_ID>"

--- a/spec/cloudscrape_client/executions/result/file_spec.rb
+++ b/spec/cloudscrape_client/executions/result/file_spec.rb
@@ -5,13 +5,13 @@ require "spec_helper"
 RSpec.describe CloudscrapeClient::Executions::Result::File do
   let(:instance) { described_class.new(value) }
 
-  let(:value) { "FILE:image/png;26071;11fed7f0-a508-4dc8-956a-481535c6f88a" }
+  let(:value) { "FILE:image/png;26071;testaccount/11fed7f0-a508-4dc8-956a-481535c6f88a" }
 
   describe "#id" do
     subject(:id) { instance.id }
 
     it "returns id parsed from value" do
-      expect(id).to eq("11fed7f0-a508-4dc8-956a-481535c6f88a")
+      expect(id).to eq("testaccount/11fed7f0-a508-4dc8-956a-481535c6f88a")
     end
 
     context "when id is not found" do
@@ -77,7 +77,7 @@ Got: FILE:;26071;11fed7f0-a508-4dc8-956a-481535c6f88a"
     subject(:file_name) { instance.file_name }
 
     it "returns expected file name" do
-      expect(file_name).to eq("11fed7f0-a508-4dc8-956a-481535c6f88a-26071.png")
+      expect(file_name).to eq("testaccount/11fed7f0-a508-4dc8-956a-481535c6f88a-26071.png")
     end
   end
 


### PR DESCRIPTION
In tonsser, our file id looks like this

```
"accounts/;account_id/robots/:run_id/executions/:execution_id/lines/:lines_id/screenshot",
```

The current regex didn't expected to match on `/`, so that is fixed now